### PR TITLE
Clean up legacy code and fix approver selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,7 +253,7 @@ function filtrarEstoque() {
     } else if (ordenacao === 'quantidade') {
         itensFiltrados.sort((a, b) => (b.quantidade || 0) - (a.quantidade || 0));
     } else if (ordenacao === 'status') {
-        const getStatus = x => (x.quantidade < x.minimo) ? 0 : (x.quantidade < x.ideal) ? 1 : 2;
+        const getStatus = x => (x.quantidade < x.minimo) ? 0 : 1;
         itensFiltrados.sort((a, b) => getStatus(a) - getStatus(b));
     }
     // Atualiza tabela
@@ -272,7 +272,6 @@ function filtrarEstoque() {
             <td>${item.serie || '-'}</td>
             <td>${item.quantidade}</td>
             <td>${item.minimo}</td>
-            <td>${item.ideal}</td>
             <td><span class="${statusClass}">${status}</span></td>
             <td>
                 <button class="btn btn-sm btn-primary" onclick="abrirModalEstoque(${item.id});event.stopPropagation();">
@@ -379,23 +378,18 @@ async function gerarRelatorioEstoque() {
                             <th>Atual</th>
                             <th>Mínimo</th>
                             <th>Falta</th>
-                            <th>Ideal</th>
-                            <th>Para Ideal</th>
                         </tr>
                     </thead>
                     <tbody>
         `;
         itensAbaixoMinimo.forEach(item => {
             const faltaMinimo = item.minimo - item.quantidade;
-            const faltaIdeal = item.ideal - item.quantidade;
             html += `
                 <tr>
                     <td>${item.nome}</td>
                     <td>${item.quantidade}</td>
                     <td>${item.minimo}</td>
                     <td>${faltaMinimo}</td>
-                    <td>${item.ideal}</td>
-                    <td>${faltaIdeal}</td>
                 </tr>
             `;
         });
@@ -819,9 +813,7 @@ window.exportarRelatorio = async function(tipo) {
                 'Código/WBS': sanitizar(item.serie || '-'),
                 'Quantidade Atual': item.quantidade,
                 'Quantidade Mínima': item.minimo,
-                'Quantidade Ideal': item.ideal,
-                'Status': sanitizar(item.quantidade < item.minimo ? 'Abaixo do Mínimo' : 
-                         item.quantidade < item.ideal ? 'Abaixo do Ideal' : 'Ideal'),
+                'Status': sanitizar(item.quantidade < item.minimo ? 'Abaixo do Mínimo' : 'Ideal'),
                 'Descrição': sanitizar(item.descricao || '-'),
                 'Origem': sanitizar(item.origem || '-'),
                 'Valor': item.valor || 0,

--- a/index.html
+++ b/index.html
@@ -329,7 +329,6 @@
                                     <th>Código</th>
                                     <th>Atual</th>
                                     <th>Mínimo</th>
-                                    <th>Ideal</th>
                                     <th>Status</th>
                                     <th>Ações</th>
                                 </tr>

--- a/requisi.js
+++ b/requisi.js
@@ -801,12 +801,16 @@ async function carregarUsuariosAprovador() {
         const response = await fetch(`${API_URL}/usuarios`);
         if (!response.ok) throw new Error('Erro ao carregar usuários');
         
-        const usuarios = await response.json();
+        const usuariosResponse = await response.json();
+        const usuarios = Array.isArray(usuariosResponse)
+            ? usuariosResponse
+            : (usuariosResponse.usuarios || []);
+        const usuariosAdmins = usuarios.filter(u => u.userType === 'admin');
         const aprovadorSelect = document.getElementById('centroCustoAprovador');
         
         if (aprovadorSelect) {
             aprovadorSelect.innerHTML = '<option value="">Selecione um aprovador...</option>';
-            usuarios.forEach(usuario => {
+            usuariosAdmins.forEach(usuario => {
                 const option = document.createElement('option');
                 option.value = usuario.id;
                 option.textContent = usuario.name;


### PR DESCRIPTION
Remove all remnants of "abaixo do ideal" functionality and ensure the approver selection dropdown displays only admin users.

The "abaixo do ideal" status was a deprecated feature, and its remaining references in tables, reports, and export logic have been fully removed to streamline the stock management system. Additionally, the approver selection in cost center settings now correctly filters and displays only users with administrative privileges.

---
<a href="https://cursor.com/background-agent?bcId=bc-86d32e34-9d12-4083-bbad-dab71e5515cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86d32e34-9d12-4083-bbad-dab71e5515cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

