### PR TITLE
Fix request creation and cost center loading

### DIFF
--- a/requisi.js
+++ b/requisi.js
@@ -233,10 +233,11 @@ async function inicializarSistemaRequisicoes() {
             await carregarRequisicoesPendentes();
         }
         
-        // Only load centers of cost if we're on the configuration tab
+        // Carregar centros de custo para o formulário de novo pacote
+        await carregarConfiguracoesPacotes();
+        // Se estiver na aba de configurações, também carregar a tabela
         const currentSection = document.querySelector('.content-section.active');
         if (currentSection && currentSection.id === 'configuracoes') {
-            await carregarConfiguracoesPacotes();
             await carregarCentrosCusto();
         }
         
@@ -807,6 +808,9 @@ function showSection(sectionId) {
         // Load centers of cost configuration
         carregarConfiguracoesPacotes();
         carregarCentrosCusto();
+    } else if (sectionId === 'novoPacote') {
+        // Garantir que o select de centro de custo esteja carregado ao abrir a criação
+        carregarConfiguracoesPacotes();
     }
     
     // Fazer scroll para o topo da página com múltiplas opções para garantir compatibilidade

--- a/server.js
+++ b/server.js
@@ -261,7 +261,7 @@ app.post('/api/unificar-itens', async (req, res) => {
 // Rotas para pacotes de requisições
 app.post('/api/pacotes', async (req, res) => {
     try {
-        const { userId, centroCusto, justificativa, itens } = req.body;
+        const { userId, centroCusto, justificativa, itens, projeto: projetoBody } = req.body;
         
         if (!userId || !centroCusto || !justificativa || !itens || !Array.isArray(itens) || itens.length === 0) {
             return res.status(400).json({
@@ -291,7 +291,8 @@ app.post('/api/pacotes', async (req, res) => {
         const pacoteId = await db.criarPacoteRequisicao({
             userId,
             centroCusto,
-            projeto,
+            // Campo projeto foi removido do pacote; manter compatibilidade aceitando valor opcional
+            projeto: projetoBody || null,
             justificativa
         });
 
@@ -302,7 +303,7 @@ app.post('/api/pacotes', async (req, res) => {
                 itemId: item.id,
                 quantidade: item.quantidade,
                 centroCusto,
-                projeto,
+                projeto: projetoBody || null,
                 justificativa: `PACOTE: ${justificativa}`,
                 pacoteId
             });


### PR DESCRIPTION
Fixes `ReferenceError: projeto is not defined` during package creation and ensures cost center select is always populated.

The `projeto` field was referenced in `server.js` without being destructured from the request body, causing a `ReferenceError`. Additionally, the cost center data was not consistently loaded in `requisi.js` on initial page load or when navigating to the package creation section, leading to an intermittently empty select menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-82a37c3d-0fb9-4451-b5d3-d41bce040209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82a37c3d-0fb9-4451-b5d3-d41bce040209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

